### PR TITLE
Improves Error Logging

### DIFF
--- a/PredictNowClient.cs
+++ b/PredictNowClient.cs
@@ -359,6 +359,13 @@ public class PredictNowClient : IDisposable
     private bool TryRequest<T>(HttpRequestMessage request, out T result)
     {
         result = default;
+
+        if (request.RequestUri == null)
+        {
+            Log.Error($"TryRequest(): Error: RequestUri cannot be null");
+            return false;
+        }
+
         var responseContent = string.Empty;
         var errorCode = HttpStatusCode.OK;
 

--- a/PredictNowClient.cs
+++ b/PredictNowClient.cs
@@ -18,6 +18,7 @@ using Python.Runtime;
 using QuantConnect.Configuration;
 using QuantConnect.Logging;
 using QuantConnect.PredictNowNET.Models;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text;
 
@@ -359,13 +360,15 @@ public class PredictNowClient : IDisposable
     {
         result = default;
         var responseContent = string.Empty;
+        var errorCode = HttpStatusCode.OK;
 
         try
         {
             var response = _client.Send(request);
+            errorCode = response.StatusCode;
             if (!response.IsSuccessStatusCode)
             {
-                Log.Error($"TryRequest({request.RequestUri.LocalPath}): Content: {response.Content}");
+                Log.Error($"TryRequest({request.RequestUri.LocalPath}): Status: {errorCode}, Response content: {response.Content.ReadAsStringAsync().Result}");
                 return false;
             }
             responseContent = response.Content.ReadAsStringAsync().Result;
@@ -373,7 +376,7 @@ public class PredictNowClient : IDisposable
         }
         catch (Exception e)
         {
-            Log.Error($"TryRequest({request.RequestUri.LocalPath}): Error: {e.Message}, Response content: {responseContent}");
+            Log.Error($"TryRequest({request.RequestUri.LocalPath}): Error: {e.Message}, Status: {errorCode}, Response content: {responseContent}");
         }
         return result != null;
     }


### PR DESCRIPTION
On QuantConnect Cloud, we can see the following error messages:

```
 '2024-02-28T15:43:50.4728059Z ERROR:: TryRequest(/get-backtest-weights): Content: System.Net.Http.HttpConnectionResponseContent\n',
 '2024-02-28T15:44:04.1016673Z ERROR:: TryRequest(/get-backtest-performance): Content: System.Net.Http.HttpConnectionResponseContent\n',
```

They don't explain the error or give us the status code.